### PR TITLE
New endpoint to return all templates edits

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def create_demo_data(db_manager):
         original_update_date=datetime.now(),
         date_start=datetime.now(),
     )
-    db_manager.database.set_allow_sync(False)
+    db_manager.database.set_allow_sync(True)
 
 
 def git_create_file_with_content(test_repo):

--- a/uiqmako_api/api/edits.py
+++ b/uiqmako_api/api/edits.py
@@ -19,7 +19,6 @@ router = APIRouter(
 @router.get("")
 async def templates_edits_list():
     templates_edits = await get_all_templates_edits()
-    templates_edits.sort(key=lambda x: x.name)
     return templates_edits
 
 @router.post("/{template_id}", dependencies=[Depends(check_erp_conn)])

--- a/uiqmako_api/api/edits.py
+++ b/uiqmako_api/api/edits.py
@@ -16,6 +16,11 @@ router = APIRouter(
     tags=['edits'],
 )
 
+@router.get("")
+async def templates_edits_list():
+    templates_edits = await get_all_templates_edits()
+    templates_edits.sort(key=lambda x: x.name)
+    return templates_edits
 
 @router.post("/{template_id}", dependencies=[Depends(check_erp_conn)])
 async def start_edit(template_id: int, current_user: User = Depends(get_current_active_user)):

--- a/uiqmako_api/models/__init__.py
+++ b/uiqmako_api/models/__init__.py
@@ -12,7 +12,7 @@ database = peewee_async.PostgresqlDatabase(
 
 def get_db_manager():
     objects = peewee_async.Manager(database)
-    database.set_allow_sync(False)
+    database.set_allow_sync(True)
     return objects
 
 

--- a/uiqmako_api/models/edits.py
+++ b/uiqmako_api/models/edits.py
@@ -76,7 +76,20 @@ async def get_edit_orm(edit_id):
     instances = [e for e in edit]
     return instances[0] if instances else False
 
-
 async def delete_edit_orm(edit_id):
     edit = await get_edit_orm(edit_id)
     return await db.delete(edit)
+
+async def get_all_edits_orm():
+    try:
+        edits = await db.execute(
+            TemplateEditModel
+            .select(TemplateEditModel, UserModel, TemplateInfoModel)
+            .join(UserModel, on=(UserModel.id == TemplateEditModel.user))
+            .join(TemplateInfoModel, on=(TemplateInfoModel.id == TemplateEditModel.template_id))
+        )
+
+        result = [TemplateEditUser.from_orm(e) for e in edits]
+        return result
+    except peewee.DoesNotExist as e:
+        return []

--- a/uiqmako_api/models/edits.py
+++ b/uiqmako_api/models/edits.py
@@ -85,10 +85,9 @@ async def get_all_edits_orm():
         edits = await db.execute(
             TemplateEditModel
             .select(TemplateEditModel, UserModel, TemplateInfoModel)
-            .join(UserModel, on=(UserModel.id == TemplateEditModel.user))
-            .join(TemplateInfoModel, on=(TemplateInfoModel.id == TemplateEditModel.template_id))
+            .join(TemplateInfoModel, on=(TemplateEditModel.template == TemplateInfoModel.id))
+            .join(UserModel, on=(TemplateEditModel.user == UserModel.id))
         )
-
         result = [TemplateEditUser.from_orm(e) for e in edits]
         return result
     except peewee.DoesNotExist as e:

--- a/uiqmako_api/models/templates.py
+++ b/uiqmako_api/models/templates.py
@@ -33,7 +33,6 @@ class CaseModel(peewee.Model):
 
 async def get_all_templates_orm():
     templates = await db.execute(TemplateInfoModel.select())
-    result = [TemplateInfoBase.from_orm(t) for t in templates]
     return templates
 
 

--- a/uiqmako_api/schemas/edits.py
+++ b/uiqmako_api/schemas/edits.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import json
 from pydantic import BaseModel
 from uiqmako_api.schemas.users import User
-from uiqmako_api.schemas.templates import Template
+from uiqmako_api.schemas.templates import TemplateInfoBase
 
 class TemplateEditInfo(BaseModel):
     template_id: int
@@ -15,7 +15,7 @@ class TemplateEditInfo(BaseModel):
 
 class TemplateEditUser(TemplateEditInfo):
     user: User
-    template: Template
+    template: TemplateInfoBase
 
     class Config:
         orm_mode = True

--- a/uiqmako_api/schemas/edits.py
+++ b/uiqmako_api/schemas/edits.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import json
 from pydantic import BaseModel
 from uiqmako_api.schemas.users import User
+from uiqmako_api.schemas.templates import Template
 
 class TemplateEditInfo(BaseModel):
     template_id: int
@@ -14,12 +15,12 @@ class TemplateEditInfo(BaseModel):
 
 class TemplateEditUser(TemplateEditInfo):
     user: User
+    template: Template
 
     class Config:
         orm_mode = True
 
 class TemplateEdit(TemplateEditInfo):
-
     body_text: str = None
     headers: str = None
     original_update_date: datetime

--- a/uiqmako_api/schemas/templates.py
+++ b/uiqmako_api/schemas/templates.py
@@ -34,14 +34,6 @@ class TemplateInfoBase(BaseModel):
     class Config:
         orm_mode = True
 
-
-class TemplateInfoEdit(BaseModel):
-    id: int
-    name: str
-
-    class Config:
-        orm_mode = True
-
 class CaseBase(BaseModel):
     """
     Test Case for a template

--- a/uiqmako_api/schemas/templates.py
+++ b/uiqmako_api/schemas/templates.py
@@ -35,6 +35,13 @@ class TemplateInfoBase(BaseModel):
         orm_mode = True
 
 
+class TemplateInfoEdit(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
 class CaseBase(BaseModel):
     """
     Test Case for a template

--- a/uiqmako_api/utils/edits.py
+++ b/uiqmako_api/utils/edits.py
@@ -6,12 +6,14 @@ from uiqmako_api.models.edits import (
     get_or_create_template_edit_orm,
     get_user_edits_info_orm,
     update_user_edit_orm,
+    get_all_edits_orm,
 )
 from uiqmako_api.utils.erp_service import ErpService
 from uiqmako_api.models.templates import (
     get_case_orm,
     get_template_orm,
 )
+from uiqmako_api.schemas.edits import TemplateEditUser
 import json
 
 async def get_or_create_template_edit(template_id, user):
@@ -70,3 +72,7 @@ async def upload_edit(erp, edit_id, delete_current_edit=True):
     if delete_current_edit:
         await delete_edit_orm(edit_id)
     return edit.template.id
+
+async def get_all_templates_edits():
+    edits = await get_all_edits_orm()
+    return edits


### PR DESCRIPTION
Add `templates_edits_list` endpoint that returns all current edits including template and user information.

We could not find a way to perform a double join without getting errors using `database.set_allow_sync(False)`. 