### PR TITLE
Fix: update all existing body translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,22 @@ Open [http://localhost:8000/docs](http://localhost:8000/docs) or [http://localho
 
 6. Run tests  and coverage
 
-```
+```bash
     createdb test_uiqmako
     cp test/.env.test.example test/.env.test
     # Review and edit test/.env.test
     poetry run pytest -v --cov=uiqmako_api
 ```
+
+Some infrastructure tests that access private servers are disabled by default until
+you enable them using env var `UIQMAKO_TEST_ERP`.
+
+```bash
+    UIQMAKO_TEST_ERP=1 poetry run pytest -v --cov=uiqmako_api
+```
+
+## Server deploy
+
+## Releasing
+
+## Deploying upgrades

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ import shutil, os
 
 from uiqmako_api.schemas.users import UserCategory
 
+pytest.register_assert_rewrite("tests.erp_service_testsuite")
+
 """"
 @pytest.fixture
 def template_infos():

--- a/tests/erp_service_testsuite.py
+++ b/tests/erp_service_testsuite.py
@@ -311,7 +311,7 @@ class ErpService_TestSuite:
             'ca_ES': edited.def_subject_ca_ES,
         }
 
-    async def test__save_template__clonesBodyToItsTranslations(self, erp_service, erp_translations):
+    async def test__save_template__bodyTranslation_cloneSuppoerted(self, erp_service, erp_translations):
         edited = edited_values()
 
         await erp_service.save_template(
@@ -322,6 +322,37 @@ class ErpService_TestSuite:
         assert erp_translations.list('def_body_text') == {
             'es_ES': edited.def_body_text,
             'ca_ES': edited.def_body_text,
+        }
+
+    async def test__save_template__bodyTranslation_cloneMissingSupported(self, erp_service, erp_translations):
+        erp_translations.remove('def_body_text', 'es_ES')
+
+        edited = edited_values()
+
+        await erp_service.save_template(
+            id = existing_template.erp_id,
+            **edited,
+        )
+
+        assert erp_translations.list('def_body_text') == {
+            'es_ES': edited.def_body_text,
+            'ca_ES': edited.def_body_text,
+        }
+
+    async def test__save_template__bodyTranslation_cloneExistingUnsupported(self, erp_service, erp_translations):
+        erp_translations.edit('def_body_text', 'en_US', dict(value='Former value'), create=True)
+
+        edited = edited_values()
+
+        await erp_service.save_template(
+            id = existing_template.erp_id,
+            **edited,
+        )
+
+        assert erp_translations.list('def_body_text') == {
+            'es_ES': edited.def_body_text,
+            'ca_ES': edited.def_body_text,
+            'en_US': edited.def_body_text,
         }
 
     @pytest.mark.skip("Not yet deployed in testing")

--- a/tests/erp_service_testsuite.py
+++ b/tests/erp_service_testsuite.py
@@ -248,31 +248,27 @@ class ErpService_TestSuite:
 
     async def test__save_template__changingEditableFields(self, erp_service):
         edited = edited_values()
-        edited_new_values = dict(**edited)
-        edited_new_values['body_text'] = 'New body'
         await erp_service.save_template(
             id = existing_template.erp_id,
-            **edited_new_values,
+            **edited,
         )
 
         retrieved = await erp_service.load_template(existing_template.xml_id)
 
-        result = dict(
+        expected = dict(
             **edited,
             id = existing_template.erp_id,
             name = existing_template.name, # Unchanged!
             model_int_name = existing_template.model, # Unchanged!
         )
 
-        assert retrieved.dict() == result
+        assert retrieved.dict() == expected
 
     async def test__save_template__usingSemanticId(self, erp_service):
         edited = edited_values()
-        edited_new_values = dict(**edited)
-        edited_new_values['body_text'] = 'New body'
         await erp_service.save_template(
             id = existing_template.xml_id,
-            **edited_new_values,
+            **edited,
         )
 
         retrieved = await erp_service.load_template(existing_template.xml_id)
@@ -289,12 +285,9 @@ class ErpService_TestSuite:
             def_subject_ca_ES = "", # <- This changes
         )
 
-        edited_new_values = dict(**edited)
-        edited_new_values['body_text'] = 'New body'
-
         await erp_service.save_template(
             id = existing_template.erp_id,
-            **edited_new_values,
+            **edited,
         )
 
         assert erp_translations.list('def_subject') == {
@@ -308,12 +301,9 @@ class ErpService_TestSuite:
 
         edited = edited_values()
 
-        edited_new_values = dict(**edited)
-        edited_new_values['body_text'] = 'New body'
-
         await erp_service.save_template(
             id = existing_template.erp_id,
-            **edited_new_values,
+            **edited,
         )
 
         assert erp_translations.list('def_subject') == {
@@ -324,12 +314,9 @@ class ErpService_TestSuite:
     async def test__save_template__clonesBodyToItsTranslations(self, erp_service, erp_translations):
         edited = edited_values()
 
-        edited_new_values = dict(**edited)
-        edited_new_values['body_text'] = 'New body'
-
         await erp_service.save_template(
             id = existing_template.erp_id,
-            **edited_new_values,
+            **edited,
         )
 
         assert erp_translations.list('def_body_text') == {

--- a/tests/erp_service_testsuite.py
+++ b/tests/erp_service_testsuite.py
@@ -4,7 +4,7 @@ from uiqmako_api.schemas.templates import Template
 from uiqmako_api.errors.exceptions import InvalidId, XmlIdNotFound
 
 """
-Those are the test that are run for both ErpService and ErpServiceDouble.
+Tests that are run for both ErpService and ErpServiceDouble.
 They are important to preserve the functionality parity between them
 so that tests on the rest of the software can be safely run against
 the double.
@@ -12,7 +12,7 @@ the double.
 This test suite refers fixtures that should be implemented in derived classes:
 
 - erp_service: Returns an instance of the ErpService
-- erp_backdoor: Encapsulation on some operation performed agains the ERP
+- erp_backdoor: Encapsulation on some operation performed against the ERP from the test
 - erp_translations: Like erp_backdoor but specialized in erp field translations
 """
 

--- a/tests/test_erp_service.py
+++ b/tests/test_erp_service.py
@@ -106,14 +106,24 @@ def erp_translations(rollback_erp):
             if not translation_id: return
             self.erp.IrTranslation.unlink(translation_id)
 
-        def edit(self, field, lang, values):
+        def edit(self, field, lang, values, create=False):
             translation_id = self.erp.IrTranslation.search([
                 ('name', '=', self.model+','+field),
                 ('res_id', '=', existing_template.erp_id),
                 ('lang', '=', lang),
             ])
-            if not translation_id: return
-            self.erp.IrTranslation.write(translation_id, values)
+            if translation_id:
+                self.erp.IrTranslation.write(translation_id, values)
+                return
+            if not create: return
+            self.erp.IrTranslation.create(dict(
+                dict(
+                    name= self.model+','+field,
+                    res_id=existing_template.erp_id,
+                    lang=lang,
+                ),
+                **values, # values overwrite name, res_id and lang
+            ))
 
     return TranslationsHelper(rollback_erp)
 

--- a/tests/test_erp_service_double.py
+++ b/tests/test_erp_service_double.py
@@ -18,6 +18,8 @@ def erp_service():
         def_subject = "Untranslated subject",
         def_subject_es_ES = existing_template.subject_es_ES,
         def_subject_ca_ES = existing_template.subject_ca_ES,
+        def_body_text_es_ES = "Previous Body",
+        def_body_text_ca_ES = "Previous Body",
         name = existing_template.name,
         model_int_name = existing_template.model,
     )
@@ -30,11 +32,6 @@ def erp_translations(erp_service):
             self.service = service
 
         def list(self, field):
-            if field == 'def_body_text':
-                return {
-                    'ca_ES': '',
-                    'es_ES': '',
-                }
             template = self.service.data.templates[existing_template.xml_id]
             prefix = field+'_'
             return {
@@ -48,13 +45,14 @@ def erp_translations(erp_service):
             translated_field = f'{field}_{language}'
             template = self.service.data.templates[existing_template.xml_id]
             if translated_field in template:
-                template[translated_field]=''
+                del template[translated_field]
 
-        def edit(self, field, lang, values):
+        def edit(self, field, lang, values, create=False):
             translated_field = f'{field}_{lang}'
             template = self.service.data.templates[existing_template.xml_id]
             if 'value' in values:
-                template[translated_field]=values['value']
+                if create or translated_field in template:
+                    template[translated_field]=values['value']
             if 'lang' in values and values['lang'] != lang:
                 template[translated_field] = ''
 
@@ -86,7 +84,5 @@ def erp_backdoor(erp_service):
     return BackendBackdoor(erp_service)
 
 class Test_ErpServiceDouble(ErpService_TestSuite):
-
-    def test__save_template__clonesBodyToItsTranslations(self, erp_backdoor, erp_translations):
-        """Body traslations are still a implementation detaiil"""
+    pass
 

--- a/uiqmako_api/utils/edits.py
+++ b/uiqmako_api/utils/edits.py
@@ -69,7 +69,7 @@ async def upload_edit(erp, edit_id, delete_current_edit=True):
     await erp.service().save_template(
         **dict(
             json.loads(edit.headers),
-            body_text=edit.body_text,
+            def_body_text=edit.body_text,
             id=edit.template.xml_id,
         )
     )

--- a/uiqmako_api/utils/erp_service.py
+++ b/uiqmako_api/utils/erp_service.py
@@ -231,7 +231,8 @@ class ErpService(object):
             if lang not in edited_languages:
                 continue
 
-            language_to_create.remove(lang)
+            if lang in language_to_create:
+                language_to_create.remove(lang)
 
             if not fields[prefix + lang]:
                 self._IrTranslation.unlink(translation_id)

--- a/uiqmako_api/utils/erp_service.py
+++ b/uiqmako_api/utils/erp_service.py
@@ -131,7 +131,6 @@ class ErpService(object):
     # TODO: Should receive a full object or dict not edition fields body and header
     async def save_template(self, id, **fields):
         erp_id = await self.erp_id(TEMPLATE_MODEL, id)
-        fields['def_body_text'] = fields['body_text']
         self._PoweremailTemplates.write(erp_id, {
             key: fields[key]
             for key in self._template_editable_fields


### PR DESCRIPTION
This PR fixes the behavior when uploading templates having the erp translations of the body to unsupported languages (others than ca_ES and es_ES). 
This Fix was requested in: https://secure.helpscout.net/conversation/2076604196/13797978?folderId=3063450

## Previous behaviour

When a template is uploaded, the body content is copied to the translations of the supported languages, regardless they previously exist or not. But if a translation to an unsupported language exists, it is not updated at all. This is dangerous because if poweremail decides to use that language, a translation not edited from uiqmako will be sent to the user.

## Fixed behaviour

Still, the new body text is used to to create or update translations of the supported languages, but now, any other translation of the body existing in the erp is updated as well. No translations are created beyond the  supported ones, but every existing translations is updated.

## Additional refactors and fixes:

- A previous fix for an attribute missmatch (`body_text` vs `def_body_text`) has been redone to move the parameter mapping to `upload_edit`. This simplifies the service by having just a parameter to care of. Also is more symetric with `load_template` and simplifies the test and the translation handling needed for this PR.
- The ErpServiceDouble now implements inner translation details to make the tests more twin and reliable.
- The common testsuite has been registered for pytest to rewrite the asserts. This way we can get information when a test fails like it was a regular test.

