### PR TITLE
🐛 changed type field for model in irTranslation

### DIFF
--- a/uiqmako_api/utils/erp_service.py
+++ b/uiqmako_api/utils/erp_service.py
@@ -248,7 +248,7 @@ class ErpService(object):
             if not fields[prefix + lang]:
                 continue
             self._IrTranslation.create(dict(
-                type='field',
+                type='model',
                 name=qualified_field,
                 res_id=object_id,
                 lang=lang,


### PR DESCRIPTION
## Description

There was an error creating the irTranslation object.

## Changes

- Set type to `model` instead of `field`


