### PR TITLE
Just allow one edit for each template

### DIFF
--- a/uiqmako_api/models/edits.py
+++ b/uiqmako_api/models/edits.py
@@ -10,7 +10,7 @@ db = get_db_manager()
 
 class TemplateEditModel(peewee.Model):
     id = peewee.AutoField()
-    template = peewee.ForeignKeyField(TemplateInfoModel, backref="edits")
+    template = peewee.ForeignKeyField(TemplateInfoModel, backref="edits", unique=True)
     user = peewee.ForeignKeyField(UserModel, backref="edits")
     body_text = peewee.TextField(null=True)
     headers = peewee.TextField(null=True)


### PR DESCRIPTION
## Description

Avoid multiple edits of the same template.

https://trello.com/c/d8uZP5ox/343-uiqmako-fer-el-transferir-nom%C3%A9s-disponible-per-a-admins

Related to https://github.com/Som-Energia/uiqmako-ui/pull/27

## Changes

- `template` field of edits now is unique



