### PR TITLE
Create a break line for plane editors to show the line change

### DIFF
--- a/uiqmako_api/utils/edits.py
+++ b/uiqmako_api/utils/edits.py
@@ -73,7 +73,7 @@ async def upload_edit(erp, edit_id, delete_current_edit=True):
     await erp.service().save_template(
         **dict(
             json.loads(edit.headers),
-            def_body_text=edit.body_text,
+            def_body_text=edit.body_text.replace("<br><br>","<br>\n<br>"),
             id=edit.template.xml_id,
         )
     )


### PR DESCRIPTION
## Description

When a template is edited in UiQMako HTML mode, the break lines with `\n` are removed. [It's a limitation of the text editor we use](https://stackoverflow.com/questions/71348810/preserve-white-space-line-breaks-in-tinymce-wysiwyg-editor), [Tiny](https://www.tiny.cloud/). This means that when users preview the resulting mail before sending it in the ERP, it looks collapsed, and it's difficult for them to identify the parts they want to review or edit.

## Changes

We create a `\n` between two `<br>` just before upload the raw code to the ERP template.

## Observations

https://somenergia.openproject.com/wp/407
